### PR TITLE
Fix coe type to enum

### DIFF
--- a/v1/baymodels/models/properties.json
+++ b/v1/baymodels/models/properties.json
@@ -13,8 +13,11 @@
   "coe": {
     "type": "string",
     "description": "The Container Orchestration Engine for this bay model",
-    "minLength": 1,
-    "maxLength": 255
+    "enum": [
+      "kubernetes",
+      "swarm",
+      "mesos"
+    ]
   },
   "imageId": {
     "type": "string",


### PR DESCRIPTION
According to current fix at Magnum[1], BayModel#coe type
is wtypes.Enum.
This patch apply that change.

[1]: https://review.openstack.org/#/c/276585/